### PR TITLE
Optimized find_function

### DIFF
--- a/tinyexpr.c
+++ b/tinyexpr.c
@@ -99,7 +99,7 @@ static const builtin *find_function(const char *name, int len) {
     while (imax >= imin) {
         const int i = (imin + ((imax-imin)/2));
         int c = strncmp(name, functions[i].name, len);
-        if (!c) c = len - strlen(functions[i].name);
+		if (!c) c = '\0' - functions[i].name[len];
         if (c == 0) {
             return functions + i;
         } else if (c > 0) {

--- a/tinyexpr.c
+++ b/tinyexpr.c
@@ -99,7 +99,7 @@ static const builtin *find_function(const char *name, int len) {
     while (imax >= imin) {
         const int i = (imin + ((imax-imin)/2));
         int c = strncmp(name, functions[i].name, len);
-		if (!c) c = '\0' - functions[i].name[len];
+        if (!c) c = '\0' - functions[i].name[len];
         if (c == 0) {
             return functions + i;
         } else if (c > 0) {
@@ -117,7 +117,7 @@ static const double *find_var(const state *s, const char *name, int len) {
     int i;
     if (!s->lookup) return 0;
     for (i = 0; i < s->lookup_len; ++i) {
-        if (s->lookup[i].name[len] == '\0' && strncmp(name, s->lookup[i].name, len) == 0) {
+        if (strncmp(name, s->lookup[i].name, len) == 0 && s->lookup[i].name[len] == '\0') {
             return s->lookup[i].value;
         }
     }

--- a/tinyexpr.c
+++ b/tinyexpr.c
@@ -117,7 +117,7 @@ static const double *find_var(const state *s, const char *name, int len) {
     int i;
     if (!s->lookup) return 0;
     for (i = 0; i < s->lookup_len; ++i) {
-        if (strlen(s->lookup[i].name) == len && strncmp(name, s->lookup[i].name, len) == 0) {
+        if (s->lookup[i].name[len] == '\0' && strncmp(name, s->lookup[i].name, len) == 0) {
             return s->lookup[i].value;
         }
     }


### PR DESCRIPTION
On find_function:
Calling strlen after verifying that up until 'len', the function name is
equal to the name we're trying to find, is unnecessary. We need only
check the char after the last one checked by strncmp, and if that
char is char is greater than '\0', that means it isn't the end of the
name, so we know that 'len - strlen(functions[i].name' is less than 0.
If the char is equal to '\0', then we know it is the end, and we return
that function, and it is impossible for the char to be less than '\0',
as it was impossible for 'len - strlen(functions[i].name' to be less
than 0, because strncmp returned 0, meaning that the length of
functions[i].name is greater or equal to 'len'.

strlen calculates the length of a string by looping until the '\0' char
is found, and removing it makes the code much faster. The impact may not
be obvious, but it would for names much larger than the ones present.

On find_var:
Same concept, but simpler, if I check the last char, and it isn't '\0',
then the strings must be different, no need to loop twice with the
strlen call.