### PR TITLE
Avoid missing initializer warnings

### DIFF
--- a/tinyexpr.c
+++ b/tinyexpr.c
@@ -116,32 +116,32 @@ static double e() {return 2.71828182845904523536;}
 
 static const te_variable functions[] = {
     /* must be in alphabetical order */
-    {"abs", fabs,     TE_FUNCTION1 | TE_FLAG_PURE},
-    {"acos", acos,    TE_FUNCTION1 | TE_FLAG_PURE},
-    {"asin", asin,    TE_FUNCTION1 | TE_FLAG_PURE},
-    {"atan", atan,    TE_FUNCTION1 | TE_FLAG_PURE},
-    {"atan2", atan2,  TE_FUNCTION2 | TE_FLAG_PURE},
-    {"ceil", ceil,    TE_FUNCTION1 | TE_FLAG_PURE},
-    {"cos", cos,      TE_FUNCTION1 | TE_FLAG_PURE},
-    {"cosh", cosh,    TE_FUNCTION1 | TE_FLAG_PURE},
-    {"e", e,          TE_FUNCTION0 | TE_FLAG_PURE},
-    {"exp", exp,      TE_FUNCTION1 | TE_FLAG_PURE},
-    {"floor", floor,  TE_FUNCTION1 | TE_FLAG_PURE},
-    {"ln", log,       TE_FUNCTION1 | TE_FLAG_PURE},
+    {"abs", fabs,     TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"acos", acos,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"asin", asin,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"atan", atan,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"atan2", atan2,  TE_FUNCTION2 | TE_FLAG_PURE, 0},
+    {"ceil", ceil,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"cos", cos,      TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"cosh", cosh,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"e", e,          TE_FUNCTION0 | TE_FLAG_PURE, 0},
+    {"exp", exp,      TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"floor", floor,  TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"ln", log,       TE_FUNCTION1 | TE_FLAG_PURE, 0},
 #ifdef TE_NAT_LOG
-    {"log", log,      TE_FUNCTION1 | TE_FLAG_PURE},
+    {"log", log,      TE_FUNCTION1 | TE_FLAG_PURE, 0},
 #else
-    {"log", log10,    TE_FUNCTION1 | TE_FLAG_PURE},
+    {"log", log10,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
 #endif
-    {"log10", log10,  TE_FUNCTION1 | TE_FLAG_PURE},
-    {"pi", pi,        TE_FUNCTION0 | TE_FLAG_PURE},
-    {"pow", pow,      TE_FUNCTION2 | TE_FLAG_PURE},
-    {"sin", sin,      TE_FUNCTION1 | TE_FLAG_PURE},
-    {"sinh", sinh,    TE_FUNCTION1 | TE_FLAG_PURE},
-    {"sqrt", sqrt,    TE_FUNCTION1 | TE_FLAG_PURE},
-    {"tan", tan,      TE_FUNCTION1 | TE_FLAG_PURE},
-    {"tanh", tanh,    TE_FUNCTION1 | TE_FLAG_PURE},
-    {0}
+    {"log10", log10,  TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"pi", pi,        TE_FUNCTION0 | TE_FLAG_PURE, 0},
+    {"pow", pow,      TE_FUNCTION2 | TE_FLAG_PURE, 0},
+    {"sin", sin,      TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"sinh", sinh,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"sqrt", sqrt,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"tan", tan,      TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"tanh", tanh,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {0, 0, 0, 0}
 };
 
 static const te_variable *find_builtin(const char *name, int len) {


### PR DESCRIPTION
With "-Wall -Wextra" gcc options i get a bunch of "missing initializer" warnings compiling TinyExpr. The fix is easy and doesn't mess the source code. So i guess it could be merged.