### PR TITLE
Avoid fall through warnings

### DIFF
--- a/tinyexpr.c
+++ b/tinyexpr.c
@@ -99,12 +99,12 @@ static te_expr *new_expr(const int type, const te_expr *parameters[]) {
 void te_free_parameters(te_expr *n) {
     if (!n) return;
     switch (TYPE_MASK(n->type)) {
-        case TE_FUNCTION7: case TE_CLOSURE7: te_free(n->parameters[6]);
-        case TE_FUNCTION6: case TE_CLOSURE6: te_free(n->parameters[5]);
-        case TE_FUNCTION5: case TE_CLOSURE5: te_free(n->parameters[4]);
-        case TE_FUNCTION4: case TE_CLOSURE4: te_free(n->parameters[3]);
-        case TE_FUNCTION3: case TE_CLOSURE3: te_free(n->parameters[2]);
-        case TE_FUNCTION2: case TE_CLOSURE2: te_free(n->parameters[1]);
+        case TE_FUNCTION7: case TE_CLOSURE7: te_free(n->parameters[6]);     /* Falls through. */
+        case TE_FUNCTION6: case TE_CLOSURE6: te_free(n->parameters[5]);     /* Falls through. */
+        case TE_FUNCTION5: case TE_CLOSURE5: te_free(n->parameters[4]);     /* Falls through. */
+        case TE_FUNCTION4: case TE_CLOSURE4: te_free(n->parameters[3]);     /* Falls through. */
+        case TE_FUNCTION3: case TE_CLOSURE3: te_free(n->parameters[2]);     /* Falls through. */
+        case TE_FUNCTION2: case TE_CLOSURE2: te_free(n->parameters[1]);     /* Falls through. */
         case TE_FUNCTION1: case TE_CLOSURE1: te_free(n->parameters[0]);
     }
 }
@@ -260,12 +260,12 @@ void next_token(state *s) {
                             s->bound = var->address;
                             break;
 
-                        case TE_CLOSURE0: case TE_CLOSURE1: case TE_CLOSURE2: case TE_CLOSURE3:
-                        case TE_CLOSURE4: case TE_CLOSURE5: case TE_CLOSURE6: case TE_CLOSURE7:
-                            s->context = var->context;
+                        case TE_CLOSURE0: case TE_CLOSURE1: case TE_CLOSURE2: case TE_CLOSURE3:         /* Falls through. */
+                        case TE_CLOSURE4: case TE_CLOSURE5: case TE_CLOSURE6: case TE_CLOSURE7:         /* Falls through. */
+                            s->context = var->context;                                                  /* Falls through. */
 
-                        case TE_FUNCTION0: case TE_FUNCTION1: case TE_FUNCTION2: case TE_FUNCTION3:
-                        case TE_FUNCTION4: case TE_FUNCTION5: case TE_FUNCTION6: case TE_FUNCTION7:
+                        case TE_FUNCTION0: case TE_FUNCTION1: case TE_FUNCTION2: case TE_FUNCTION3:     /* Falls through. */
+                        case TE_FUNCTION4: case TE_FUNCTION5: case TE_FUNCTION6: case TE_FUNCTION7:     /* Falls through. */
                             s->type = var->type;
                             s->function = var->address;
                             break;


### PR DESCRIPTION
In order to get a clean compilation with -Wextra on gcc 7.2 (Ubuntu 17.10) i added few comments.
This avoids a bunch of Wimplicit-fallthrough warnings.
It is not a big change, so i guess it could be easily merged.

https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/