### PR TITLE
CLang: macro name is a reserved identifier

### DIFF
--- a/tinyexpr.h
+++ b/tinyexpr.h
@@ -22,8 +22,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef __TINYEXPR_H__
-#define __TINYEXPR_H__
+#ifndef TINYEXPR_H
+#define TINYEXPR_H
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixing CLang's warning: macro name is a reserved identifier [-Wreserved-id-macro] . According to https://www.gnu.org/software/libc/manual/html_node/Reserved-Names.html, a global name should not start with an underscore.