### PR TITLE
Handle malloc failures

### DIFF
--- a/tinyexpr.c
+++ b/tinyexpr.c
@@ -86,6 +86,10 @@ static te_expr *new_expr(const int type, const te_expr *parameters[]) {
     const int psize = sizeof(void*) * arity;
     const int size = (sizeof(te_expr) - sizeof(void*)) + psize + (IS_CLOSURE(type) ? sizeof(void*) : 0);
     te_expr *ret = malloc(size);
+    if (ret == NULL) {
+        return NULL;
+    }
+
     memset(ret, 0, size);
     if (arity && parameters) {
         memcpy(ret->parameters, parameters, psize);
@@ -305,12 +309,20 @@ static te_expr *base(state *s) {
     switch (TYPE_MASK(s->type)) {
         case TOK_NUMBER:
             ret = new_expr(TE_CONSTANT, 0);
+            if (ret == NULL) {
+                return NULL;
+            }
+
             ret->value = s->value;
             next_token(s);
             break;
 
         case TOK_VARIABLE:
             ret = new_expr(TE_VARIABLE, 0);
+            if (ret == NULL) {
+                return NULL;
+            }
+
             ret->bound = s->bound;
             next_token(s);
             break;
@@ -318,6 +330,10 @@ static te_expr *base(state *s) {
         case TE_FUNCTION0:
         case TE_CLOSURE0:
             ret = new_expr(s->type, 0);
+            if (ret == NULL) {
+                return NULL;
+            }
+
             ret->function = s->function;
             if (IS_CLOSURE(s->type)) ret->parameters[0] = s->context;
             next_token(s);
@@ -334,10 +350,18 @@ static te_expr *base(state *s) {
         case TE_FUNCTION1:
         case TE_CLOSURE1:
             ret = new_expr(s->type, 0);
+            if (ret == NULL) {
+                return NULL;
+            }
+
             ret->function = s->function;
             if (IS_CLOSURE(s->type)) ret->parameters[1] = s->context;
             next_token(s);
             ret->parameters[0] = power(s);
+            if (ret->parameters[0] == NULL) {
+                free(ret);
+                return NULL;
+            }
             break;
 
         case TE_FUNCTION2: case TE_FUNCTION3: case TE_FUNCTION4:
@@ -347,6 +371,10 @@ static te_expr *base(state *s) {
             arity = ARITY(s->type);
 
             ret = new_expr(s->type, 0);
+            if (ret == NULL) {
+                return NULL;
+            }
+
             ret->function = s->function;
             if (IS_CLOSURE(s->type)) ret->parameters[arity] = s->context;
             next_token(s);
@@ -358,6 +386,15 @@ static te_expr *base(state *s) {
                 for(i = 0; i < arity; i++) {
                     next_token(s);
                     ret->parameters[i] = expr(s);
+                    if (ret->parameters[i] == NULL) {
+                        int j;
+                        for (j = 0; j < i; ++j) {
+                            te_free(ret->parameters[j]);
+                        }
+                        free(ret);
+                        return NULL;
+                    }
+
                     if(s->type != TOK_SEP) {
                         break;
                     }
@@ -374,6 +411,10 @@ static te_expr *base(state *s) {
         case TOK_OPEN:
             next_token(s);
             ret = list(s);
+            if (ret == NULL) {
+                return NULL;
+            }
+
             if (s->type != TOK_CLOSE) {
                 s->type = TOK_ERROR;
             } else {
@@ -383,6 +424,10 @@ static te_expr *base(state *s) {
 
         default:
             ret = new_expr(0, 0);
+            if (ret == NULL) {
+                return NULL;
+            }
+
             s->type = TOK_ERROR;
             ret->value = NAN;
             break;
@@ -405,7 +450,17 @@ static te_expr *power(state *s) {
     if (sign == 1) {
         ret = base(s);
     } else {
-        ret = NEW_EXPR(TE_FUNCTION1 | TE_FLAG_PURE, base(s));
+        te_expr *b = base(s);
+        if (b == NULL) {
+            return NULL;
+        }
+
+        ret = NEW_EXPR(TE_FUNCTION1 | TE_FLAG_PURE, b);
+        if (ret == NULL) {
+            te_free(b);
+            return NULL;
+        }
+
         ret->function = negate;
     }
 
@@ -416,6 +471,9 @@ static te_expr *power(state *s) {
 static te_expr *factor(state *s) {
     /* <factor>    =    <power> {"^" <power>} */
     te_expr *ret = power(s);
+    if (ret == NULL) {
+        return NULL;
+    }
 
     int neg = 0;
 
@@ -434,19 +492,50 @@ static te_expr *factor(state *s) {
 
         if (insertion) {
             /* Make exponentiation go right-to-left. */
-            te_expr *insert = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, insertion->parameters[1], power(s));
+            te_expr *p = power(s);
+            if (p == NULL) {
+                te_free(ret);
+                return NULL;
+            }
+
+            te_expr *insert = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, insertion->parameters[1], p);
+            if (insert == NULL) {
+                te_free(p);
+                te_free(ret);
+                return NULL;
+            }
+
             insert->function = t;
             insertion->parameters[1] = insert;
             insertion = insert;
         } else {
-            ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, power(s));
+            te_expr *p = power(s);
+            if (p == NULL) {
+                te_free(ret);
+                return NULL;
+            }
+
+            te_expr *prev = ret;
+            ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, p);
+            if (ret == NULL) {
+                te_free(p);
+                te_free(prev);
+                return NULL;
+            }
+
             ret->function = t;
             insertion = ret;
         }
     }
 
     if (neg) {
+        te_expr *prev = ret;
         ret = NEW_EXPR(TE_FUNCTION1 | TE_FLAG_PURE, ret);
+        if (ret == NULL) {
+            te_free(prev);
+            return NULL;
+        }
+
         ret->function = negate;
     }
 
@@ -456,11 +545,27 @@ static te_expr *factor(state *s) {
 static te_expr *factor(state *s) {
     /* <factor>    =    <power> {"^" <power>} */
     te_expr *ret = power(s);
+    if (ret == NULL) {
+        return NULL;
+    }
 
     while (s->type == TOK_INFIX && (s->function == pow)) {
         te_fun2 t = s->function;
         next_token(s);
-        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, power(s));
+        te_expr *p = power(s);
+        if (p == NULL) {
+            te_free(ret);
+            return NULL;
+        }
+
+        te_expr *prev = ret;
+        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, p);
+        if (ret == NULL) {
+            te_free(p);
+            te_free(prev);
+            return NULL;
+        }
+
         ret->function = t;
     }
 
@@ -473,11 +578,27 @@ static te_expr *factor(state *s) {
 static te_expr *term(state *s) {
     /* <term>      =    <factor> {("*" | "/" | "%") <factor>} */
     te_expr *ret = factor(s);
+    if (ret == NULL) {
+        return NULL;
+    }
 
     while (s->type == TOK_INFIX && (s->function == mul || s->function == divide || s->function == fmod)) {
         te_fun2 t = s->function;
         next_token(s);
-        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, factor(s));
+        te_expr *f = factor(s);
+        if (f == NULL) {
+            te_free(ret);
+            return NULL;
+        }
+
+        te_expr *prev = ret;
+        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, f);
+        if (ret == NULL) {
+            te_free(f);
+            te_free(prev);
+            return NULL;
+        }
+
         ret->function = t;
     }
 
@@ -488,11 +609,27 @@ static te_expr *term(state *s) {
 static te_expr *expr(state *s) {
     /* <expr>      =    <term> {("+" | "-") <term>} */
     te_expr *ret = term(s);
+    if (ret == NULL) {
+        return NULL;
+    }
 
     while (s->type == TOK_INFIX && (s->function == add || s->function == sub)) {
         te_fun2 t = s->function;
         next_token(s);
-        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, term(s));
+        te_expr *te = term(s);
+        if (te == NULL) {
+            te_free(ret);
+            return NULL;
+        }
+
+        te_expr *prev = ret;
+        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, te);
+        if (ret == NULL) {
+            te_free(te);
+            te_free(prev);
+            return NULL;
+        }
+
         ret->function = t;
     }
 
@@ -503,10 +640,26 @@ static te_expr *expr(state *s) {
 static te_expr *list(state *s) {
     /* <list>      =    <expr> {"," <expr>} */
     te_expr *ret = expr(s);
+    if (ret == NULL) {
+        return NULL;
+    }
 
     while (s->type == TOK_SEP) {
         next_token(s);
-        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, expr(s));
+        te_expr *e = expr(s);
+        if (e == NULL) {
+            te_free(ret);
+            return NULL;
+        }
+
+        te_expr *prev = ret;
+        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, e);
+        if (ret == NULL) {
+            te_free(e);
+            te_free(prev);
+            return NULL;
+        }
+
         ret->function = comma;
     }
 
@@ -595,6 +748,10 @@ te_expr *te_compile(const char *expression, const te_variable *variables, int va
 
     next_token(&s);
     te_expr *root = list(&s);
+    if (root == NULL) {
+        if (error) *error = -1;
+        return NULL;
+    }
 
     if (s.type != TOK_END) {
         te_free(root);
@@ -613,6 +770,10 @@ te_expr *te_compile(const char *expression, const te_variable *variables, int va
 
 double te_interp(const char *expression, int *error) {
     te_expr *n = te_compile(expression, 0, 0, error);
+    if (n == NULL) {
+        return NAN;
+    }
+
     double ret;
     if (n) {
         ret = te_eval(n);


### PR DESCRIPTION
This PR adds handling for malloc failures. I don't quite know how one would add sane test cases to cover it, but I did test it manually by replaceing malloc with a malloc implementation which returns NULL 10% of the time, and all of the existing test cases run fine, with no memory errors or memory leaks. The only problem was one place in `smoke.c` which uses the return value of `te_interp` without checking for errors.

The approach to error checking is the most basic one; just add a whole bunch of `if (ret == NULL) { ...; return NULL; }` everywhere. It's not the prettiest, but it works. The alternative would be to `setjmp` at the beginning of `te_compile`, then `longjmp` out of `new_expr`. It would probably be faster, but `setjmp` and `longjmp` is honestly really scary, with a lot of space for accidentally stepping into undefined behavior (for example, all variables which are modified between the `setjmp` and the `longjmp` must be volatile). A `longjmp`-based approach would probably be faster though.

---

The reason behind doing this isn't _just_ that I think `malloc` failures should be handled in general. I also think this is a possible approach for custom allocators such as allocators which allocate from a pool of static memory. Here's how I imagine a viable path to statically allocated tinyexpr:

* Once malloc failures are handled gracefully, add `TE_MALLOC` and `TE_FREE` macros which default to `malloc` and `free` but can be overwritten at compile time.
* I can then add `-DTE_MALLOC=static_te_malloc -DTE_FREE=static_te_free` to my tinyexpr.c compile options.
* I can then define those functions like this in my own code:

``` C
static _Alignas(8) char buffer[1024];
static size_t allocs = 0;
static size_t offset = 0;

void *static_te_malloc(size_t count) {
    while (count % 8 != 0) count += 1; // Align
    if (offset + count >= sizeof(buffer)) {
        return NULL; // This will be handled properly by tinyexpr
    }

    void *ptr = buffer + offset;
    offset += count;
    allocs += 1;
    return ptr;
}

void static_te_free(void *ptr) {
    if (ptr == NULL) return;
    allocs -= 1;
    if (allocs == 0) {
        offset = 0; // All memory freed
    }
}
```

I personally find this to be a cleaner, simpler and more flexible solution than adding explicit support for using a static memory pool to tinyexpr itself.

I decided to not include those macros in this PR, because it's kind of orthogonal, and I think handling malloc failures has value regardless of whether or not you agree with my idea for supporting custom allocators.

---

Obviously, adding extra `if`s everywhere has a performance cost (though only at te_compile time, not te_eval time). Here are times I got from running `hyperfine ./bench.orig ./bench.new` (where `bench.new` is the benchmarking suite with this patch):

```
Benchmark #1: ./bench.orig
  Time (mean ± σ):     17.170 s ±  0.178 s    [User: 17.164 s, System: 0.004 s]
  Range (min … max):   16.818 s … 17.485 s    10 runs

Benchmark #2: ./bench.new
  Time (mean ± σ):     18.342 s ±  1.088 s    [User: 18.341 s, System: 0.001 s]
  Range (min … max):   17.937 s … 21.431 s    10 runs

Summary
  './bench.orig' ran
    1.07 ± 0.06 times faster than './bench.new'
```

Here's the output from the unmodified benchmark suite on my machine:

```
martin@ubun ~/src/tinyexpr master $ ./bench.orig
Expression: a+5
native  5.0045e+11        260ms   384mfps
interp  5.0045e+11        621ms   161mfps
138.85% longer

Expression: 5+a+5
native  5.0095e+11        224ms   446mfps
interp  5.0095e+11        984ms   101mfps
339.29% longer

Expression: abs(a+5)
native  5.0045e+11        222ms   450mfps
interp  5.0045e+11        798ms   125mfps
259.46% longer

Expression: sqrt(a^1.5+a^2.5)
native  4.4443e+12       3323ms    30mfps
interp  4.4443e+12       4696ms    21mfps
41.32% longer

Expression: a+(5*2)
native  5.0095e+11        223ms   448mfps
interp  5.0095e+11        637ms   156mfps
185.65% longer

Expression: (a+5)*2
native  1.0009e+12        225ms   444mfps
interp  1.0009e+12        981ms   101mfps
336.00% longer

Expression: (1/(a+1)+2/(a+2)+3/(a+3))
native  5.2226e+05        297ms   336mfps
interp  5.2226e+05       3241ms    30mfps
991.25% longer
```

And the benchmark suite with this patch: 

```
martin@ubun ~/src/tinyexpr master $ ./bench.new
Expression: a+5
native  5.0045e+11        259ms   386mfps
interp  5.0045e+11        698ms   143mfps
169.50% longer

Expression: 5+a+5
native  5.0095e+11        223ms   448mfps
interp  5.0095e+11       1169ms    85mfps
424.22% longer

Expression: abs(a+5)
native  5.0045e+11        223ms   448mfps
interp  5.0045e+11        892ms   112mfps
300.00% longer

Expression: sqrt(a^1.5+a^2.5)
native  4.4443e+12       3340ms    29mfps
interp  4.4443e+12       4671ms    21mfps
39.85% longer

Expression: a+(5*2)
native  5.0095e+11        224ms   446mfps
interp  5.0095e+11        758ms   131mfps
238.39% longer

Expression: (a+5)*2
native  1.0009e+12        223ms   448mfps
interp  1.0009e+12       1150ms    86mfps
415.70% longer

Expression: (1/(a+1)+2/(a+2)+3/(a+3))
native  5.2226e+05        327ms   305mfps
interp  5.2226e+05       3834ms    26mfps
1072.48% longer
```