### PR TITLE
C11 and C++20

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ the standard C math functions and runtime binding of variables.
 ## Features
 
 - **C99 with no dependencies**.
+- Can also be compiled with C++20.
 - Single source file and header file.
 - Simple and fast.
 - Implements standard operators precedence.
-- Exposes standard C math functions (sin, sqrt, ln, etc.).
+- Exposes standard C math functions (sin, sqrt, log, etc.).
 - Can add custom functions and variables easily.
 - Can bind variables at eval-time.
 - Released under the zlib license - free for nearly any use.
@@ -101,7 +102,7 @@ After you're finished, make sure to call `te_free()`.
 
     int err;
     /* Compile the expression with variables. */
-    te_expr *expr = te_compile("sqrt(x^2+y^2)", vars, 2, &err);
+    te_expr *expr = te_compile("sqrt(x**2+y**2)", vars, 2, &err);
 
     if (expr) {
         x = 3; y = 4;
@@ -163,20 +164,20 @@ line. It also does error checking and binds the variables `x` and `y` to *3* and
 
 
 This produces the output:
-
-    $ example2 "sqrt(x^2+y2)"
+```
+    $ example2 "sqrt(x**2+y2)"
         Evaluating:
-                sqrt(x^2+y2)
+                sqrt(x**2+y2)
                           ^
         Error near here
 
 
-    $ example2 "sqrt(x^2+y^2)"
+    $ example2 "sqrt(x**2+y**2)"
         Evaluating:
-                sqrt(x^2+y^2)
+                sqrt(x**2+y**2)
         Result:
                 5.000000
-
+```
 
 ## Binding to Custom Functions
 
@@ -228,12 +229,12 @@ Here is some example performance numbers taken from the included
 **benchmark.c** program:
 
 | Expression | te_eval time | native C time | slowdown  |
-| :------------- |-------------:| -----:|----:|
-| sqrt(a^1.5+a^2.5) | 15,641 ms | 14,478 ms | 8% slower |
-| a+5 | 765 ms | 563 ms | 36% slower |
-| a+(5*2) | 765 ms | 563 ms | 36% slower |
-| (a+5)*2 | 1422 ms | 563 ms | 153% slower |
-| (1/(a+1)+2/(a+2)+3/(a+3)) | 5,516 ms | 1,266 ms | 336% slower |
+| :---------------------------|----------:|----------:|------------:|
+| `sqrt(a**1.5+a**2.5)`       | 15,641 ms | 14,478 ms | 8% slower   |
+| `a+5`                       | 765 ms    | 563 ms    | 36% slower  |
+| `a+(5*2)`                   | 765 ms    | 563 ms    | 36% slower  |
+| `(a+5)*2`                   | 1422 ms   | 563 ms    | 153% slower |
+| `(1/(a+1)+2/(a+2)+3/(a+3))` | 5,516 ms  | 1,266 ms  | 336% slower |
 
 
 
@@ -244,7 +245,7 @@ TinyExpr parses the following grammar:
     <list>      =    <expr> {"," <expr>}
     <expr>      =    <term> {("+" | "-") <term>}
     <term>      =    <factor> {("*" | "/" | "%") <factor>}
-    <factor>    =    <power> {"^" <power>}
+    <factor>    =    <power> {"*\*" <power>}
     <power>     =    {("-" | "+")} <base>
     <base>      =    <constant>
                    | <variable>
@@ -265,46 +266,25 @@ for *0.5*)
 ## Functions supported
 
 TinyExpr supports addition (+), subtraction/negation (-), multiplication (\*),
-division (/), exponentiation (^) and modulus (%) with the normal operator
+division (/), exponentiation (*\*) and modulus (%) with the normal operator
 precedence (the one exception being that exponentiation is evaluated
 left-to-right, but this can be changed - see below).
 
 The following C math functions are also supported:
 
-- abs (calls to *fabs*), acos, asin, atan, atan2, ceil, cos, cosh, exp, floor, ln (calls to *log*), log (calls to *log10* by default, see below), log10, pow, sin, sinh, sqrt, tan, tanh
+- abs, acos, asin, atan, atan2, cbrt, ceil, cos, cosh, exp, floor, gamma, log, log2, log10, pow, sin, sinh, sqrt, tan, tanh
 
 The following functions are also built-in and provided by TinyExpr:
 
 - fac (factorials e.g. `fac 5` == 120)
 - ncr (combinations e.g. `ncr(6,2)` == 15)
 - npr (permutations e.g. `npr(6,2)` == 30)
+- gcd (common denominator e.g. `gcd(30, 50)` == 10)
 
 Also, the following constants are available:
 
 - `pi`, `e`
 
-
-## Compile-time options
-
-
-By default, TinyExpr does exponentiation from left to right. For example:
-
-`a^b^c == (a^b)^c` and `-a^b == (-a)^b`
-
-This is by design. It's the way that spreadsheets do it (e.g. Excel, Google Sheets).
-
-
-If you would rather have exponentiation work from right to left, you need to
-define `TE_POW_FROM_RIGHT` when compiling `tinyexpr.c`. There is a
-commented-out define near the top of that file. With this option enabled, the
-behaviour is:
-
-`a^b^c == a^(b^c)` and `-a^b == -(a^b)`
-
-That will match how many scripting languages do it (e.g. Python, Ruby).
-
-Also, if you'd like `log` to default to the natural log instead of `log10`,
-then you can define `TE_NAT_LOG`.
 
 ## Hints
 
@@ -316,4 +296,3 @@ then you can define `TE_NAT_LOG`.
   parentheses are important, because TinyExpr will not change the order of
   evaluation. If you instead compiled "x+1+5" TinyExpr will insist that "1" is
   added to "x" first, and "5" is added the result second.
-

--- a/example.c
+++ b/example.c
@@ -1,9 +1,9 @@
-#include "tinyexpr.h"
+#include "tinyexpr.c"
 #include <stdio.h>
 
 int main(int argc, char *argv[])
 {
-    const char *c = "sqrt(5^2+7^2+11^2+(8-2)^2)";
+    const char *c = "sqrt(5**2 * 2 + 7**2 + 11**2 + (8 - 2)**2)";
     double r = te_interp(c, 0);
     printf("The expression:\n\t%s\nevaluates to:\n\t%f\n", c, r);
     return 0;

--- a/example3.c
+++ b/example3.c
@@ -12,7 +12,7 @@ double my_sum(double a, double b) {
 int main(int argc, char *argv[])
 {
     te_variable vars[] = {
-        {"mysum", my_sum, TE_FUNCTION2}
+        {.name="mysum", .fun2=my_sum, .type=TE_FUNCTION2}
     };
 
     const char *expression = "mysum(5, 6)";

--- a/tinyexpr.c
+++ b/tinyexpr.c
@@ -122,20 +122,8 @@ void te_free(te_expr *n) {
 
 static double pi(void) {return 3.14159265358979323846;}
 static double e(void) {return 2.71828182845904523536;}
-static double fac(double a) {/* simplest version of fac */
-    if (a < 0.0)
-        return NAN;
-    if (a > UINT_MAX)
-        return INFINITY;
-    unsigned int ua = (unsigned int)(a);
-    unsigned long int result = 1, i;
-    for (i = 1; i <= ua; i++) {
-        if (i > ULONG_MAX / result)
-            return INFINITY;
-        result *= i;
-    }
-    return (double)result;
-}
+static double fac(double a) {return tgamma(a + 1);}
+
 static double ncr(double n, double r) {
     if (n < 0.0 || r < 0.0 || n < r) return NAN;
     if (n > UINT_MAX || r > UINT_MAX) return INFINITY;

--- a/tinyexpr.h
+++ b/tinyexpr.h
@@ -29,13 +29,16 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+/* Private */
+typedef double (*te_fun0)(void);
+typedef double (*te_fun1)(double);
+typedef double (*te_fun2)(double, double);
 
-
-
+/* Public */
 typedef struct te_expr {
     int type;
-    union {double value; const double *bound; const void *function;};
-    void *parameters[1];
+    union {double value; const double *bound; te_fun0 fun0; te_fun1 fun1; te_fun2 fun2;};
+    struct te_expr *parameters[1];
 } te_expr;
 
 
@@ -53,9 +56,9 @@ enum {
 
 typedef struct te_variable {
     const char *name;
-    const void *address;
+    union {const double *address; te_fun0 fun0; te_fun1 fun1; te_fun2 fun2;};
     int type;
-    void *context;
+    te_expr *context;
 } te_variable;
 
 


### PR DESCRIPTION
- Replaces unsafe usages of const void* with appropriate pointer types for data and functions, making the code maximum portable, safe, and easier to maintain. Detail: Some compilers does not allow casting between data and function pointers, even void* (pointers may have different sizes).

- Library now compilable both in c11 and c++20. Useful if you need to customize the code with a c++ allocator or use it in projects where c++ source code is required. Broadens usability of the library.

Note that it is only unnamed structs that requires C11, but unnamed structs are supported on every C99 compiler that I know of (including MSVC which isn't even C99 compliant).

- For c++, the PR forces the correct overloaded math functions to be picked during function pointer assignments and comparisons, e.g. like pow and fmod.

- Simplifies casting code in te_eval() by adding a few macros, can extend number of function parameters cleanly.