### PR TITLE
Accepted upper case letters

### DIFF
--- a/tinyexpr.c
+++ b/tinyexpr.c
@@ -39,6 +39,7 @@ For log = natural log uncomment the next line. */
 #include <math.h>
 #include <string.h>
 #include <stdio.h>
+#include <ctype.h>
 #include <limits.h>
 
 #ifndef NAN
@@ -245,8 +246,8 @@ void next_token(state *s) {
             if (s->next[0] >= 'a' && s->next[0] <= 'z') {
                 const char *start;
                 start = s->next;
-                while ((s->next[0] >= 'a' && s->next[0] <= 'z') || (s->next[0] >= '0' && s->next[0] <= '9') || (s->next[0] == '_')) s->next++;
-
+                while (isalpha(s->next[0]) || isdigit(s->next[0]) || (s->next[0] == '_')) s->next++;
+                
                 const te_variable *var = find_lookup(s, start, s->next - start);
                 if (!var) var = find_builtin(start, s->next - start);
 


### PR DESCRIPTION
Introduced `isalpha()` from `<ctype.h>` to check if a character belongs to the alphabet. Previously, only lower case letters were allowed.

Also introduced `isdigit()`, since it is part of `<ctype.h>` and makes the code cleaner.