### PR TITLE
Fixed for the old issue #34

### DIFF
--- a/tinyexpr.c
+++ b/tinyexpr.c
@@ -151,6 +151,11 @@ static double ncr(double n, double r) {
 }
 static double npr(double n, double r) {return ncr(n, r) * fac(r);}
 
+#ifdef _MSC_VER
+#pragma function (ceil)
+#pragma function (floor)
+#endif
+
 static const te_variable functions[] = {
     /* must be in alphabetical order */
     {"abs", fabs,     TE_FUNCTION1 | TE_FLAG_PURE, 0},


### PR DESCRIPTION
As I got hit with the same issue when compiling tinyexpr on Windows with QtCreator (that itself was calling Visual C++ 2017 in the background) and realized that there was a solution in the issue's thread but no fix in the source code, I've implemented it (wrapped with ifdef to prevent warnings on other platforms).

I don't know why the solution given in the thread was not implemented, but just in case if this just got lost, here it is!