### PR TITLE
Use flexible array notation for te_expr

### DIFF
--- a/tinyexpr.c
+++ b/tinyexpr.c
@@ -86,7 +86,7 @@ typedef struct state {
 static te_expr *new_expr(const int type, const te_expr *parameters[]) {
     const int arity = ARITY(type);
     const int psize = sizeof(void*) * arity;
-    const int size = (sizeof(te_expr) - sizeof(void*)) + psize + (IS_CLOSURE(type) ? sizeof(void*) : 0);
+    const int size = sizeof(te_expr) + psize + (IS_CLOSURE(type) ? sizeof(void*) : 0);
     te_expr *ret = malloc(size);
     memset(ret, 0, size);
     if (arity && parameters) {

--- a/tinyexpr.h
+++ b/tinyexpr.h
@@ -36,7 +36,7 @@ extern "C" {
 typedef struct te_expr {
     int type;
     union {double value; const double *bound; const void *function;};
-    void *parameters[1];
+    void *parameters[];
 } te_expr;
 
 


### PR DESCRIPTION
Newer gcc gets confused when malloc stores a bunch of memory in a
one-element array.  C99 "flexible array" notation achieves the same
effect in a more standard way.