### PR TITLE
Typo Fix

### DIFF
--- a/tinyexpr.c
+++ b/tinyexpr.c
@@ -158,7 +158,7 @@ static double npr(double n, double r) {return ncr(n, r) * fac(r);}
 
 static const te_variable functions[] = {
     /* must be in alphabetical order */
-    {"abs", fabs,     TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"abs", abs,     TE_FUNCTION1 | TE_FLAG_PURE, 0},
     {"acos", acos,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
     {"asin", asin,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
     {"atan", atan,    TE_FUNCTION1 | TE_FLAG_PURE, 0},


### PR DESCRIPTION
When attempting to use tyinyexpr.c & .h in an arduino project I found the following error:
```
C:\Users\[account]\AppData\Local\Temp\cc7WQBuw.ltrans0.ltrans.o:(.rodata+0x2): undefined reference to `fabs'

collect2.exe: error: ld returned 1 exit status

exit status 1
Error compiling for board Arduino/Genuino Uno.
```

The change brings the abs function name into line with the naming of other functions and fixes this issue. 