### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ the standard C math functions and runtime binding of variables.
 TinyExpr is self-contained in two files: `tinyexpr.c` and `tinyexpr.h`. To use
 TinyExpr, simply add those two files to your project.
 
+Alternatively, you can build and install tinyexpr using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+```C
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+    ./vcpkg integrate install
+    ./vcpkg install tinyexpr
+```
+
+The tinyexpr port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Short Example
 
 Here is a minimal example to evaluate an expression at runtime.


### PR DESCRIPTION
Tinyexpr is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for tinyexpr and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build tinyexpr, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/tinyexpr/portfile.cmake). We try to keep the library maintained as close as possible to the original library.