### PR TITLE
Document hexadecimal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,9 +256,10 @@ TinyExpr parses the following grammar:
 In addition, whitespace between tokens is ignored.
 
 Valid variable names consist of a letter followed by any combination of:
-letters, the digits *0* through *9*, and underscore. Constants can be integers,
-decimal numbers, or in scientific notation (e.g.  *1e3* for *1000*). A leading
-zero is not required (e.g. *.5* for *0.5*)
+letters, the digits *0* through *9*, and underscore. Constants can be integers
+or floating-point numbers, and can be in decimal, hexadecimal (e.g., *0x57CEF7*),
+or scientific notation (e.g., *1e3* for *1000*).
+A leading zero is not required (e.g., *.5* for *0.5*).
 
 
 ## Functions supported


### PR DESCRIPTION
`strtod` supports hexadecimal out of the box if prefixed with `0x`, so document that *tinyexpr* can handle these values. I've tested on all three platforms.