### PR TITLE
Fix compilation warnings when using MSVC on x64 architecture

### DIFF
--- a/tinyexpr.c
+++ b/tinyexpr.c
@@ -67,7 +67,7 @@ typedef struct state {
     const char *start;
     const char *next;
     int type;
-    union {double value; const double *bound; const void *function;};
+    union {double value; const double *bound; void *function;};
     void *context;
 
     const te_variable *lookup;
@@ -192,7 +192,7 @@ static const te_variable functions[] = {
     {0, 0, 0, 0}
 };
 
-static const te_variable *find_builtin(const char *name, int len) {
+static const te_variable *find_builtin(const char *name, size_t len) {
     int imin = 0;
     int imax = sizeof(functions) / sizeof(te_variable) - 2;
 
@@ -213,7 +213,7 @@ static const te_variable *find_builtin(const char *name, int len) {
     return 0;
 }
 
-static const te_variable *find_lookup(const state *s, const char *name, int len) {
+static const te_variable *find_lookup(const state *s, const char *name, size_t len) {
     int iters;
     const te_variable *var;
     if (!s->lookup) return 0;
@@ -662,7 +662,7 @@ static void optimize(te_expr *n) {
 }
 
 
-te_expr *te_compile(const char *expression, const te_variable *variables, int var_count, int *error) {
+te_expr *te_compile(const char *expression, const te_variable *variables, int var_count, size_t *error) {
     state s;
     s.start = s.next = expression;
     s.lookup = variables;
@@ -690,7 +690,7 @@ te_expr *te_compile(const char *expression, const te_variable *variables, int va
 }
 
 
-double te_interp(const char *expression, int *error) {
+double te_interp(const char *expression, size_t *error) {
     te_expr *n = te_compile(expression, 0, 0, error);
 
     double ret;

--- a/tinyexpr.h
+++ b/tinyexpr.h
@@ -54,7 +54,7 @@ enum {
 
 typedef struct te_variable {
     const char *name;
-    const void *address;
+    void *address;
     int type;
     void *context;
 } te_variable;
@@ -63,11 +63,11 @@ typedef struct te_variable {
 
 /* Parses the input expression, evaluates it, and frees it. */
 /* Returns NaN on error. */
-double te_interp(const char *expression, int *error);
+double te_interp(const char *expression, size_t *error);
 
 /* Parses the input expression and binds variables. */
 /* Returns NULL on error. */
-te_expr *te_compile(const char *expression, const te_variable *variables, int var_count, int *error);
+te_expr *te_compile(const char *expression, const te_variable *variables, int var_count, size_t *error);
 
 /* Evaluates the expression. */
 double te_eval(const te_expr *n);


### PR DESCRIPTION
When using the MSVC build tools, compilation warnings will be given regarding two issues:

1) __int64 cast to int when doing pointer arithmetic to calculate error
2) const vs non-const when assing function pointers to state

This PR changes int to size_t where appropriate and removes the const keyword from state.function and te_variable.address (const is ignored in front of the return type of a function pointer).