### PR TITLE
Add clusterfuzzlite workflow

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,8 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool cmake \
+                      pkg-config curl check
+COPY . $SRC/tinyexpr
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+COPY .clusterfuzzlite/*.cpp $SRC/
+COPY .clusterfuzzlite/*.c $SRC/
+WORKDIR tinyexpr

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -3,6 +3,5 @@ RUN apt-get update && apt-get install -y make autoconf automake libtool cmake \
                       pkg-config curl check
 COPY . $SRC/tinyexpr
 COPY .clusterfuzzlite/build.sh $SRC/build.sh
-COPY .clusterfuzzlite/*.cpp $SRC/
 COPY .clusterfuzzlite/*.c $SRC/
 WORKDIR tinyexpr

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+find . -name "*.c" -exec $CC $CFLAGS -I./src -c {} \;
+find . -name "*.o" -exec cp {} . \;
+
+rm -f ./test*.o
+llvm-ar rcs libfuzz.a *.o
+
+
+$CC $CFLAGS $LIB_FUZZING_ENGINE $SRC/fuzzer.c -Wl,--whole-archive $SRC/tinyexpr/libfuzz.a -Wl,--allow-multiple-definition -I$SRC/tinyexpr/  -o $OUT/fuzzer

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
-find . -name "*.c" -exec $CC $CFLAGS -I./src -c {} \;
-find . -name "*.o" -exec cp {} . \;
+for file in "smoke.c tinyexpr.c repl.c benchmark.c"; do
+  $CC $CFLAGS -c ${file}
+done
 
-rm -f ./test*.o
 llvm-ar rcs libfuzz.a *.o
 
 
-$CC $CFLAGS $LIB_FUZZING_ENGINE $SRC/fuzzer.c -Wl,--whole-archive $SRC/tinyexpr/libfuzz.a -Wl,--allow-multiple-definition -I$SRC/tinyexpr/  -o $OUT/fuzzer
+$CC $CFLAGS $LIB_FUZZING_ENGINE $SRC/fuzzer.c \
+  -Wl,--whole-archive $SRC/tinyexpr/libfuzz.a -Wl,--allow-multiple-definition \
+  -I$SRC/tinyexpr/  -o $OUT/fuzzer

--- a/.clusterfuzzlite/fuzzer.c
+++ b/.clusterfuzzlite/fuzzer.c
@@ -1,0 +1,30 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "minctest.h"
+#include "tinyexpr.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    if (size == 0) {
+        return 0;
+    }
+
+    char *input = (char*)malloc(size + 1);
+    if (!input) {
+        return 0;
+    }
+
+    memcpy(input, data, size);
+    input[size] = '\0';
+
+    te_variable vars[] = {{ "x", 0 }};
+    int error;
+    te_expr *result = te_compile(input, vars, 1, &error);
+
+    free(input);
+    te_free(result);
+
+    return 0;
+}

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ master ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c++
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 100
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

If you'd like to test this the way ClusterFuzzLite runs it (by way of OSS-Fuzz) you can use the steps:

```sh
git clone https://github.com/google/oss-fuzz
git clone https://github.com/DavidKorczynski/tinyexpr
cd tinyexpr
git checkout cflite

# Build the fuzzers in .clusterfuzzlite
python3 ../oss-fuzz/infra/helper.py build_fuzzers --external $PWD

# Run the fuzzer for 10 seconds
python3 ../oss-fuzz/infra/helper.py run_fuzzer --external $PWD fuzzer -- -max_total_time=10
```