### PR TITLE
Fix: possible null pointer dereference due to unchecked malloc

### DIFF
--- a/repl.c
+++ b/repl.c
@@ -29,6 +29,7 @@ static char *readline(const char *prompt) {
     }
 
     line = malloc(len + 1);
+    if (!line) return NULL;
     strcpy(line, buf);
     return line;
 }


### PR DESCRIPTION
Bug: use the ptr returned by malloc without checking that is not NULL
```C
line = malloc(len + 1);
strcpy(line, buf);
return line;
```

Solution: return NULL, because other branches of the same function also return NULL if something fails
```C
line = malloc(len + 1);
if (!line) return NULL;
strcpy(line, buf);
return line;
```

Fixes #131